### PR TITLE
Add Dockerized wiki backup tool

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+__pycache__
+.env
+output

--- a/.env.template
+++ b/.env.template
@@ -13,3 +13,6 @@ PASSWORD=
 
 # Directory to store downloaded site
 OUTPUT_DIR=output
+
+# Ignore SSL certificate errors (true/false)
+IGNORE_SSL_ERRORS=false

--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,15 @@
+# Root wiki URL
+WIKI_URL=https://wiki.example.com
+
+# Authentication method: 'cookie' or 'credentials'
+AUTH_METHOD=cookie
+
+# Session cookie string
+COOKIE=
+
+# Yandex credentials (used when AUTH_METHOD=credentials)
+USERNAME=
+PASSWORD=
+
+# Directory to store downloaded site
+OUTPUT_DIR=output

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt && \
+    playwright install --with-deps
+
+COPY . .
+
+CMD ["python", "-m", "src.backup"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This project provides a simple, containerised tool to archive an authenticated Y
 - `COOKIE` – Cookie string exported from your browser. Used when `AUTH_METHOD=cookie`.
 - `USERNAME` / `PASSWORD` – Credentials for Yandex Passport. Used when `AUTH_METHOD=credentials`.
 - `OUTPUT_DIR` – Directory where the static site will be written (default: `output`).
+- `IGNORE_SSL_ERRORS` – Set to `true` to allow crawling sites with self-signed certificates.
 
 ### Obtaining Cookies
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# yandex-wiki-backup
+# Yandex Wiki Backup
+
+This project provides a simple, containerised tool to archive an authenticated Yandex Wiki (or any JavaScript heavy wiki) into a static HTML site. All pages, images and other assets are downloaded so the result can be browsed offline.
+
+## Features
+
+- Uses [Playwright](https://playwright.dev/) for modern web automation.
+- Supports authentication via Yandex credentials or existing browser cookies.
+- Recursively crawls the wiki and rewrites links for offline use.
+- Output is a self-contained static site stored in `output/`.
+
+## Getting Started
+
+1. Copy `.env.template` to `.env` and fill in the required values.
+2. Run `docker compose up` to start the crawl. The generated site will appear in the `output/` directory.
+   An additional `viewer` service exposes the static files at <http://localhost:8080>.
+
+### Environment Variables
+
+- `WIKI_URL` – Root URL of your wiki (e.g. `https://wiki.yandex-team.ru`).
+- `AUTH_METHOD` – `cookie` or `credentials`. Determines how authentication is performed.
+- `COOKIE` – Cookie string exported from your browser. Used when `AUTH_METHOD=cookie`.
+- `USERNAME` / `PASSWORD` – Credentials for Yandex Passport. Used when `AUTH_METHOD=credentials`.
+- `OUTPUT_DIR` – Directory where the static site will be written (default: `output`).
+
+### Obtaining Cookies
+
+1. Open your wiki in a browser where you are already logged in.
+2. Open Developer Tools → Network → choose any request and copy the `Cookie` header.
+3. Paste that value into the `COOKIE` variable in your `.env` file.
+
+Using cookies avoids storing your username and password inside the container.
+
+## Authentication Notes
+
+The tool performs a login with Playwright in headless mode. When using `AUTH_METHOD=credentials` it will submit the Yandex Passport login form automatically. For single sign-on (SSO) flows or when automation is blocked, provide a valid `COOKIE` string instead.
+
+## Output
+
+The crawler writes all pages and assets relative to `OUTPUT_DIR`. Open `index.html` in that folder to browse your wiki offline.
+You can also point your browser to `http://localhost:8080` while the compose stack is running to view the site via the built-in `viewer` service.
+
+## Running natively
+
+Docker is recommended, but you can also run the script locally:
+
+```bash
+pip install -r requirements.txt
+playwright install --with-deps
+python -m src.backup
+```
+
+## Security
+
+**Never commit your real credentials.** The `.env.template` file is provided so you can create your own `.env` with private information.
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,15 @@
+services:
+  backup:
+    build: .
+    env_file:
+      - .env
+    volumes:
+      - ./output:/app/output
+    command: ["python", "-m", "src.backup"]
+
+  viewer:
+    image: nginx:alpine
+    volumes:
+      - ./output:/usr/share/nginx/html:ro
+    ports:
+      - "8080:80"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+playwright>=1.42
+beautifulsoup4
+python-dotenv

--- a/src/backup.py
+++ b/src/backup.py
@@ -80,26 +80,28 @@ class WikiCrawler:
 
 
 def authenticate(context, page, root_url: str) -> None:
-    cookie = os.getenv('COOKIE')
-    username = os.getenv('USERNAME')
-    password = os.getenv('PASSWORD')
-    if cookie:
+    method = os.getenv("AUTH_METHOD", "cookie").lower()
+    cookie = os.getenv("COOKIE")
+    username = os.getenv("USERNAME")
+    password = os.getenv("PASSWORD")
+
+    if method == "cookie" and cookie:
         cookies = []
-        for item in cookie.split(';'):
-            if '=' not in item:
+        for item in cookie.split(";"):
+            if "=" not in item:
                 continue
-            name, value = item.split('=', 1)
+            name, value = item.split("=", 1)
             cookies.append({"name": name.strip(), "value": value.strip(), "url": root_url})
         context.add_cookies(cookies)
         page.goto(root_url)
-    elif username and password:
+    elif method == "credentials" and username and password:
         login_url = f"https://passport.yandex.com/auth?retpath={root_url}"
         page.goto(login_url)
-        page.fill('input[name="login"]', username)
-        page.click('button[type="submit"]')
-        page.fill('input[name="passwd"]', password)
-        page.click('button[type="submit"]')
-        page.wait_for_load_state('networkidle')
+        page.fill("input[name='login']", username)
+        page.click("button[type='submit']")
+        page.fill("input[name='passwd']", password)
+        page.click("button[type='submit']")
+        page.wait_for_load_state("networkidle")
     else:
         page.goto(root_url)
 
@@ -114,7 +116,8 @@ def main() -> None:
 
     with sync_playwright() as p:
         browser = p.firefox.launch(headless=True)
-        context = browser.new_context()
+        ignore_ssl = os.getenv("IGNORE_SSL_ERRORS", "false").lower() in ("1", "true", "yes")
+        context = browser.new_context(ignore_https_errors=ignore_ssl)
         page = context.new_page()
         authenticate(context, page, root_url)
 

--- a/src/backup.py
+++ b/src/backup.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict, Set
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
+from dotenv import load_dotenv
+from playwright.sync_api import sync_playwright
+
+from . import utils
+
+
+class WikiCrawler:
+    def __init__(self, page, output_dir: Path, root_url: str) -> None:
+        self.page = page
+        self.output_dir = output_dir
+        self.root_url = root_url.rstrip('/')
+        self.asset_dir = output_dir / "assets"
+        utils.ensure_dir(self.asset_dir)
+        self.visited: Set[str] = set()
+        self.asset_map: Dict[str, Path] = {}
+        self.root_domain = urlparse(self.root_url).netloc
+
+    def is_internal(self, url: str) -> bool:
+        return urlparse(url).netloc == self.root_domain
+
+    def download_asset(self, url: str) -> Path | None:
+        if url in self.asset_map:
+            return self.asset_map[url]
+        response = self.page.context.request.get(url)
+        if not response.ok:
+            return None
+        dest = utils.hashed_filename(url, self.asset_dir)
+        utils.ensure_dir(dest.parent)
+        with open(dest, 'wb') as f:
+            f.write(response.body())
+        self.asset_map[url] = dest
+        return dest
+
+    def crawl(self) -> None:
+        queue = [self.root_url]
+        while queue:
+            url = queue.pop(0)
+            if url in self.visited:
+                continue
+            self.visited.add(url)
+
+            print(f"Fetching {url}")
+            self.page.goto(url, wait_until="networkidle")
+            html = self.page.content()
+            local_page = utils.url_to_local_path(url, self.output_dir, is_page=True)
+            utils.ensure_dir(local_page.parent)
+            soup = BeautifulSoup(html, 'html.parser')
+
+            # Assets
+            for tag_name, attr in (('img', 'src'), ('script', 'src'), ('link', 'href')):
+                for element in soup.find_all(tag_name):
+                    link = element.get(attr)
+                    if not link:
+                        continue
+                    full = urljoin(url, link)
+                    asset = self.download_asset(full)
+                    if asset:
+                        element[attr] = os.path.relpath(asset, local_page.parent)
+
+            # Links
+            for element in soup.find_all('a', href=True):
+                link = element['href']
+                full = urljoin(url, link)
+                if self.is_internal(full):
+                    queue.append(full)
+                    target = utils.url_to_local_path(full, self.output_dir, is_page=True)
+                    element['href'] = os.path.relpath(target, local_page.parent)
+
+            with open(local_page, 'w', encoding='utf-8') as f:
+                f.write(str(soup))
+            print(f"Saved {local_page}")
+
+
+def authenticate(context, page, root_url: str) -> None:
+    cookie = os.getenv('COOKIE')
+    username = os.getenv('USERNAME')
+    password = os.getenv('PASSWORD')
+    if cookie:
+        cookies = []
+        for item in cookie.split(';'):
+            if '=' not in item:
+                continue
+            name, value = item.split('=', 1)
+            cookies.append({"name": name.strip(), "value": value.strip(), "url": root_url})
+        context.add_cookies(cookies)
+        page.goto(root_url)
+    elif username and password:
+        login_url = f"https://passport.yandex.com/auth?retpath={root_url}"
+        page.goto(login_url)
+        page.fill('input[name="login"]', username)
+        page.click('button[type="submit"]')
+        page.fill('input[name="passwd"]', password)
+        page.click('button[type="submit"]')
+        page.wait_for_load_state('networkidle')
+    else:
+        page.goto(root_url)
+
+
+def main() -> None:
+    load_dotenv()
+    root_url = os.environ.get('WIKI_URL')
+    if not root_url:
+        raise SystemExit('WIKI_URL is required')
+    output_dir = Path(os.environ.get('OUTPUT_DIR', 'output'))
+    utils.ensure_dir(output_dir)
+
+    with sync_playwright() as p:
+        browser = p.firefox.launch(headless=True)
+        context = browser.new_context()
+        page = context.new_page()
+        authenticate(context, page, root_url)
+
+        crawler = WikiCrawler(page, output_dir, root_url)
+        crawler.crawl()
+        browser.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+def ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def url_to_local_path(url: str, output_dir: Path, is_page: bool = False) -> Path:
+    parsed = urlparse(url)
+    path = parsed.path
+    if is_page:
+        if path.endswith('/'):
+            path += 'index.html'
+        elif not Path(path).suffix:
+            path += '.html'
+    local = output_dir / path.lstrip('/')
+    return local
+
+
+def hashed_filename(url: str, output_dir: Path) -> Path:
+    ext = Path(urlparse(url).path).suffix or '.bin'
+    digest = hashlib.sha1(url.encode()).hexdigest()[:10]
+    return output_dir / f"{digest}{ext}"


### PR DESCRIPTION
## Summary
- add Playwright-based crawler for backing up Yandex Wiki
- set up Docker container and compose file
- provide environment variable template for credentials
- document usage and credential handling
- add nginx viewer service

## Testing
- `python -m py_compile src/*.py`
- `docker compose config` *(fails: `command not found: docker`)*

------
https://chatgpt.com/codex/tasks/task_e_6888e12111b08329b7da02098aa09ddb